### PR TITLE
Add Gateway to the Great Books collection

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -59,6 +59,8 @@
 		<meta id="collection-2" property="belongs-to-collection">The BBC’s 100 Greatest British Novels (2015)</meta>
 		<meta property="collection-type" refines="#collection-2">set</meta>
 		<meta property="group-position" refines="#collection-2">27</meta>
+		<meta property="collection-3" property="belongs-to-collection">Encyclopædia Britannica’s Gateway to the Great Books</meta>
+		<meta property="collection-type" refines="#collection-3">set</meta>
 		<dc:description id="description">Shipwrecked on a remote tropical island, a resourceful Englishman manages to survive alone for many years.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;&lt;i&gt;Robinson Crusoe&lt;/i&gt; is one of the most popular books ever written in the English language, published in innumerable editions and translated into almost every language of the world, not to mention the many versions created in film, television and even radio. First published in 1719, it can also claim to be one of the first novels ever written in English.&lt;/p&gt;


### PR DESCRIPTION
*[Gateway to the Great Books](https://en.wikipedia.org/wiki/Gateway_to_the_Great_Books)* is a ten‐volume set compiled by Encyclopædia Britannica as a more accessible companion to *Great Books of the Western World*. It consists primarily of short stories, essays, and excerpts from longer works.

I made a [spreadsheet](https://github.com/bentley/se-spreadsheets/blob/master/gateway-to-the-great-books.csv) to keep track of what we have (or don’t, or won’t). Here’s the current list of SE books that include *Gateway* selections:

* Robinson Crusoe
* The Jungle Book
* Wilde’s children’s stories
* Poe’s short fiction
* Dr. Jekyll and Mr. Hyde
* Gogol’s short fiction
* Erewhon
* Bunin’s short fiction
* Flaubert’s short fiction
* Chekhov’s short fiction
* Tolstoy’s short fiction
* The School for Scandal
* Enchiridion

If this is okay, I’ll make pull requests for the others.